### PR TITLE
Add '-progress' option

### DIFF
--- a/ListProgress.cc
+++ b/ListProgress.cc
@@ -1,0 +1,11 @@
+#include "ListProgress.hh"
+
+#include <iostream>
+
+void
+outputMlistProgress(int completed, int total)
+{
+  std::cout << "\033[s\033[K" // Save the cursor position & clear following text
+    << "(" << completed << "/" << total << ")" << std::flush
+    << "\033[u"; // Restore the cursor to the saved position
+}

--- a/ListProgress.hh
+++ b/ListProgress.hh
@@ -1,0 +1,7 @@
+#ifndef list_progress_hh
+#define list_progress_hh
+
+void
+outputMlistProgress(int completed, int total);
+
+#endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@
 AUTOMAKE_OPTIONS = gnu # I would like dist-bzip2 here, but automake complains
 bin_PROGRAMS = rdfind
 rdfind_SOURCES = rdfind.cc Checksum.cc  Dirlist.cc  Fileinfo.cc  Rdutil.cc \
-                 EasyRandom.cc UndoableUnlink.cc CmdlineParser.cc
+                 EasyRandom.cc UndoableUnlink.cc CmdlineParser.cc ListProgress.cc
 
 LDADD = @LIBXXHASH@
 #these are the test scripts to execute - I do not know how to glob here,

--- a/Rdutil.cc
+++ b/Rdutil.cc
@@ -543,7 +543,8 @@ int
 Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
                       enum Fileinfo::readtobuffermode lasttype,
                       const long nsecsleep,
-                      const std::size_t buffersize)
+                      const std::size_t buffersize,
+                      void (*debugProgress)(int, int))
 {
   // first sort on inode (to read efficiently from the hard drive)
   sortOnDeviceAndInode();
@@ -551,8 +552,13 @@ Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
   const auto duration = std::chrono::nanoseconds{ nsecsleep };
 
   std::vector<char> buffer(buffersize, '\0');
+  int progress = 0;
 
   for (auto& elem : m_list) {
+    if (debugProgress) {
+      progress += 1;
+      debugProgress(progress, m_list.size());
+    }
     elem.fillwithbytes(type, lasttype, buffer);
     if (nsecsleep > 0) {
       std::this_thread::sleep_for(duration);

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -90,7 +90,8 @@ public:
   int fillwithbytes(enum Fileinfo::readtobuffermode type,
                     enum Fileinfo::readtobuffermode lasttype,
                     long nsecsleep,
-                    std::size_t buffersize);
+                    std::size_t buffersize,
+                    void (*debugProgress)(int, int) = NULL);
 
   /// make symlinks of duplicates.
   std::size_t makesymlinks(bool dryrun) const;

--- a/rdfind.cc
+++ b/rdfind.cc
@@ -21,6 +21,7 @@ static_assert(__cplusplus >= 201703L,
 #include "Fileinfo.hh"    //file container
 #include "RdfindDebug.hh" //debug macro
 #include "Rdutil.hh"      //to do some work
+#include "ListProgress.hh"
 
 // global variables
 
@@ -78,6 +79,7 @@ usage()
     << " -makeresultsfile  (true)| false  makes a results file\n"
     << " -outputname  name  sets the results file name to \"name\" "
        "(default results.txt)\n"
+    << " -progress          true |(false) output progress information"
     << " -deleteduplicates  true |(false) delete duplicate files\n"
     << " -sleep             Xms          sleep for X milliseconds between "
        "file reads.\n"
@@ -118,6 +120,7 @@ struct Options
   std::size_t buffersize = 1 << 20; // chunksize to use when reading files
   long nsecsleep = 0; // number of nanoseconds to sleep between each file read.
   std::string resultsfile = "results.txt"; // results file name.
+  void (*debugProgressFuncPtr)(int, int) = NULL; // call this function for each iteration of fillwithbytes
 };
 
 Options
@@ -237,6 +240,8 @@ parseOptions(Parser& parser)
                   << nextarg << "\" is not among them.\n";
         std::exit(EXIT_FAILURE);
       }
+    } else if (parser.try_parse_bool("-progress") && parser.get_parsed_bool()) {
+      o.debugProgressFuncPtr = outputMlistProgress;
     } else if (parser.current_arg_is("-help") || parser.current_arg_is("-h") ||
                parser.current_arg_is("--help")) {
       usage();
@@ -414,7 +419,7 @@ main(int narg, const char* argv[])
               << it->second << ": " << std::flush;
 
     // read bytes (destroys the sorting, for disk reading efficiency)
-    gswd.fillwithbytes(it[0].first, it[-1].first, o.nsecsleep, o.buffersize);
+    gswd.fillwithbytes(it[0].first, it[-1].first, o.nsecsleep, o.buffersize, o.debugProgressFuncPtr);
 
     // remove non-duplicates
     std::cout << "removed " << gswd.removeUniqSizeAndBuffer()


### PR DESCRIPTION
Pursuant to https://github.com/pauldreik/rdfind/issues/30, this commit adds a '-progress' option. If set to true, then a function pointer is passed to 'fillwithbytes', with the result that each iteration of the loop in that function outputs a progress update.

The progress update appears at the end of the current line and overwrites itself with each repetition, producing an output resembling the following:

    Now eliminating candidates based on [...]: (16/19324)