### PR TITLE
Use help output for usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,55 @@ using cygwin.
 
 ## Usage
 
-    rdfind [options] directory_or_file_1 [directory_or_file_2] [directory_or_file_3] ...
+```
+Usage: rdfind [options] FILE ...
+
+Finds duplicate files recursively in the given FILEs (directories),
+and takes appropriate action (by default, nothing).
+Directories listed first are ranked higher, meaning that if a
+file is found on several places, the file found in the directory first
+encountered on the command line is kept, and the others are considered duplicate.
+
+options are (default choice within parentheses)
+
+ -ignoreempty      (true)| false  ignore empty files (true implies -minsize 1,
+                                  false implies -minsize 0)
+ -minsize N        (N=1)          ignores files with size less than N bytes
+                                  For -minsize, -maxsize and -buffersize,
+                                  Suffixes 'K', 'M', 'G' etc. up to 'E'
+                                  are accepted. Factors are 1024, not 1000.
+ -maxsize N        (N=0)          ignores files with size N bytes and larger (use 0 to disable this check).
+ -followsymlinks    true |(false) follow symlinks
+ -removeidentinode (true)| false  ignore files with nonunique device and inode
+ -checksum           md5 |(sha1)| sha256 | sha512 | xxh128
+                                  checksum type
+                                  xxh128 is very fast, but is noncryptographic.
+ -buffersize N
+                                  chunksize in bytes when calculating the checksum.
+                                  The default is 1 MiB, can be up to 128 MiB.
+ -partialchecksum  (N=0)          number of MiB to checksum from the start and end of a file instead of hashing the whole file.
+                                  Zero means hash the whole file. 1 would be 2MiB hashed
+ -deterministic    (true)| false  makes results independent of order
+                                  from listing the filesystem
+ -makesymlinks      true |(false) replace duplicate files with symbolic links
+ -makehardlinks     true |(false) replace duplicate files with hard links
+ -makeresultsfile  (true)| false  makes a results file
+ -outputname  name  sets the results file name to "name" (default results.txt)
+ -progress          true |(false) output progress information -deleteduplicates  true |(false) delete duplicate files
+ -sleep             Xms          sleep for X milliseconds between file reads.
+                                  Default is 0. Only a few values
+                                  are supported; 0,1-5,10,25,50,100
+ -dryrun|-n         true |(false) print to stdout instead of changing anything
+ -h|-help|--help                  show this help and exit
+ -v|--version                     display version number and exit
+
+If properly installed, a man page should be available as man rdfind.
+
+rdfind is written by Paul Dreik 2006 onwards. License: GPL v2 or later (at your option).
+version is 1.7.next
+```
 
 Without options, a results file will be created in the current directory. For full options, see [the man page](https://rdfind.pauldreik.se/rdfind.1.html).
-
 ## Examples
 
 Basic example, taken from a \*nix environment:


### PR DESCRIPTION
Adds the output from help to the README to quickly identify what options are available.